### PR TITLE
adds a new rule set for Perplexity

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -576,6 +576,7 @@ rules:
   # - RULE-SET,Hijacking,🛑 全部拦截
   - RULE-SET,GoogleVoice,🇺🇸 美国优选
   - RULE-SET,Bing,🇺🇸 美国优选
+  - RULE-SET,Perplexity,🧠 Perplexity
   - RULE-SET,OpenAI,🇺🇸 美国优选
   - RULE-SET,Anthropic,🇺🇸 美国优选
   - RULE-SET,Gemini,🇺🇸 美国优选


### PR DESCRIPTION
This pull request includes a small change to the `rules:` section in the `clash/config/base.yml` file. The change adds a new rule set for Perplexity.

* [`clash/config/base.yml`](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adR579): Added a new rule set for Perplexity.