### PR TITLE
add no resolve

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -395,7 +395,7 @@ rule-providers:
     format: text
   Lan:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Lan/Lan.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Lan/Lan_No_Resolve.yaml
     path: ./providers/rule-provider_Lan.yaml
   Tailscale_OfficialDERP_Doamin:
     <<: *x-rp-domain
@@ -412,7 +412,7 @@ rule-providers:
     path: ./providers/rule-provider_Download.yaml
   PrivateTracker:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PrivateTracker/PrivateTracker.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PrivateTracker/PrivateTracker_No_Resolve.yaml
     path: ./providers/rule-provider_PrivateTracker.yaml
   # Privacy_Classical:
   #   <<: *x-rp-classical
@@ -465,11 +465,11 @@ rule-providers:
     path: ./providers/rule-provider_Microsoft.yaml
   Google:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Google/Google.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Google/Google_No_Resolve.yaml
     path: ./providers/rule-provider_Google.yaml
   Apple:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Apple/Apple.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Apple/Apple_No_Resolve.yaml
     path: ./providers/rule-provider_Apple.yaml
   SteamCN:
     <<: *x-rp-classical
@@ -481,11 +481,11 @@ rule-providers:
     path: ./providers/rule-provider_Steam.yaml
   Spotify:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Spotify/Spotify.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Spotify/Spotify_No_Resolve.yaml
     path: ./providers/rule-provider_Spotify.yaml
   Qobuz:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Qobuz/Qobuz.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Qobuz/Qobuz_No_Resolve.yaml
     path: ./providers/rule-provider_Qobuz.yaml
   TIDAL:
     <<: *x-rp-classical
@@ -498,7 +498,7 @@ rule-providers:
     format: text
   YouTube:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/YouTube/YouTube.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/YouTube/YouTube_No_Resolve.yaml
     path: ./providers/rule-provider_YouTube.yaml
   Netflix:
     <<: *x-rp-classical
@@ -514,23 +514,23 @@ rule-providers:
     path: ./providers/rule-provider_Bahamut.yaml
   GlobalMedia:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GlobalMedia/GlobalMedia.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GlobalMedia/GlobalMedia_No_Resolve.yaml
     path: ./providers/rule-provider_GlobalMedia.yaml
   NetEaseMusic:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NetEaseMusic/NetEaseMusic.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NetEaseMusic/NetEaseMusic_No_Resolve.yaml
     path: ./providers/rule-provider_NetEaseMusic.yaml
   AsianMedia:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AsianMedia/AsianMedia.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AsianMedia/AsianMedia_No_Resolve.yaml
     path: ./providers/rule-provider_AsianMedia.yaml
   Telegram:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Telegram/Telegram.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Telegram/Telegram_No_Resolve.yaml
     path: ./providers/rule-provider_Telegram.yaml
   Twitter:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Twitter/Twitter.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Twitter/Twitter_No_Resolve.yaml
     path: ./providers/rule-provider_Twitter.yaml
   HighBandwidth:
     <<: *x-rp-classical
@@ -547,7 +547,7 @@ rule-providers:
     format: text
   Global:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Global/Global.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Global/Global_No_Resolve.yaml
     path: ./providers/rule-provider_Global.yaml
   Global_Domain:
     <<: *x-rp-domain
@@ -555,7 +555,7 @@ rule-providers:
     path: ./providers/rule-provider_Global_Domain.yaml
   China:
     <<: *x-rp-classical
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/China/China.yaml
+    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/China/China_No_Resolve.yaml
     path: ./providers/rule-provider_China.yaml
   China_Domain:
     <<: *x-rp-domain


### PR DESCRIPTION
This pull request updates several URLs in the `clash/config/base.yml` file to use "_No_Resolve" versions of the rule provider scripts. These changes ensure that the updated URLs point to the correct versions of the rule provider scripts that do not perform DNS resolution.

Changes to rule provider URLs:

* `Lan` rule provider URL updated to `Lan_No_Resolve.yaml` (`clash/config/base.yml`)
* `PrivateTracker` rule provider URL updated to `PrivateTracker_No_Resolve.yaml` (`clash/config/base.yml`)
* `Google` rule provider URL updated to `Google_No_Resolve.yaml` (`clash/config/base.yml`)
* `Apple` rule provider URL updated to `Apple_No_Resolve.yaml` (`clash/config/base.yml`)
* `Spotify` rule provider URL updated to `Spotify_No_Resolve.yaml` (`clash/config/base.yml`)
* `Qobuz` rule provider URL updated to `Qobuz_No_Resolve.yaml` (`clash/config/base.yml`)
* `YouTube` rule provider URL updated to `YouTube_No_Resolve.yaml` (`clash/config/base.yml`)
* `GlobalMedia` rule provider URL updated to `GlobalMedia_No_Resolve.yaml` (`clash/config/base.yml`)
* `NetEaseMusic` rule provider URL updated to `NetEaseMusic_No_Resolve.yaml` (`clash/config/base.yml`)
* `AsianMedia` rule provider URL updated to `AsianMedia_No_Resolve.yaml` (`clash/config/base.yml`)
* `Telegram` rule provider URL updated to `Telegram_No_Resolve.yaml` (`clash/config/base.yml`)
* `Twitter` rule provider URL updated to `Twitter_No_Resolve.yaml` (`clash/config/base.yml`)
* `Global` rule provider URL updated to `Global_No_Resolve.yaml` (`clash/config/base.yml`)
* `China` rule provider URL updated to `China_No_Resolve.yaml` (`clash/config/base.yml`)