### PR TITLE
fix: let RestrictedZones  ahead GlobalMedia

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -584,6 +584,7 @@ rules:
   - RULE-SET,Netflix,🎥 Netflix
   - RULE-SET,TikTok,🎥 TikTok
   - RULE-SET,Bahamut,🇹🇼 台湾优选
+  - RULE-SET,RestrictedZones,🈲 禁飞空域
   - RULE-SET,GlobalMedia,🌍 国外媒体
   - RULE-SET,NetEaseMusic,🎵 网易云音乐
   - RULE-SET,AsianMedia,🌍 国内媒体 (港澳台版切换)
@@ -591,7 +592,6 @@ rules:
   - RULE-SET,Twitter, 𝕏 Twitter
   - RULE-SET,HighBandwidth,📥 大流量分流
   - RULE-SET,Speedtest,📶 测速切换
-  - RULE-SET,RestrictedZones,🈲 禁飞空域
   - RULE-SET,Global,🔰 节点选择
   - RULE-SET,China,🎯 全部直连
   - GEOIP,CN,🎯 全部直连


### PR DESCRIPTION
This pull request includes a modification to the `rules:` section in the `clash/config/base.yml` file. The change reorders the `RestrictedZones` rule-set.

Changes in `rules:`:

* Moved the `RestrictedZones` rule-set to an earlier position in the list.