### PR TITLE
feat: update crypto Provider

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -100,7 +100,7 @@ x-pg:
     lazy: true
     include-all: true
     # hidden: true
-    exclude-filter: '(?i:专用)'
+    exclude-filter: "(?i:专用)"
 
   # select-region: &x-pp-region
   #   type: select
@@ -155,7 +155,7 @@ proxy-groups:
 
   - name: 🤖 Developer
     <<: *x-pp-select-region
-  
+
   - name: 🧠 Perplexity
     type: select
     proxies:
@@ -211,7 +211,7 @@ proxy-groups:
 
   - name: 💰 Crypto
     <<: *x-pp-select-region
-  
+
   - name: 🏦 香港银行
     <<: *x-pp-select-region
 
@@ -269,7 +269,7 @@ proxy-groups:
       - ✈️ 手动选择
       - 🎩 私有节点
       - 🏠 家宽节点
-  
+
   - name: 🈲 禁飞空域
     <<: *x-pp-select-region
     include-all: true
@@ -516,12 +516,12 @@ rule-providers:
     path: ./providers/rule-provider_Bahamut.list
   Crypto:
     <<: *x-rp-text
-    url: https://cdn.jsdelivr.net/gh/EAlyce/conf@8aa15839ca4f9b154906a0f7f3f3640c04e1e08b/Rule/CryptoDraft.list
+    url: https://cdn.jsdelivr.net/gh/EAlyce/conf@main/Rule/CryptoDraft.list
     path: ./providers/rule-provider_CryptoDraft.list
   HongKongBank:
     <<: *x-rp-text
     url: https://cdn.jsdelivr.net/gh/LeiyuG/Surge@main/rules/HongKongBank.list
-    path : ./providers/rule-provider_HongKongBank.list
+    path: ./providers/rule-provider_HongKongBank.list
   GlobalMedia:
     <<: *x-rp-text
     url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GlobalMedia/GlobalMedia.list

--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -516,8 +516,8 @@ rule-providers:
     path: ./providers/rule-provider_Bahamut.list
   Crypto:
     <<: *x-rp-text
-    url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Crypto/Crypto.list
-    path: ./providers/rule-provider_Crypto.list
+    url: https://cdn.jsdelivr.net/gh/EAlyce/conf@8aa15839ca4f9b154906a0f7f3f3640c04e1e08b/Rule/CryptoDraft.list
+    path: ./providers/rule-provider_CryptoDraft.list
   HongKongBank:
     <<: *x-rp-text
     url: https://cdn.jsdelivr.net/gh/LeiyuG/Surge@main/rules/HongKongBank.list


### PR DESCRIPTION
This pull request includes a change to the `clash/config/base.yml` file, specifically updating the `rule-providers` section. The most important change is the modification of the URL and path for the `Crypto` rule provider.

Changes in `rule-providers`:

* [`clash/config/base.yml`](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adL519-R520): Updated the `Crypto` rule provider URL and path to point to a new source.