### PR TITLE
feat(rules): 新增 appsflyersdk.com 到 Crypto.list

### DIFF
--- a/clash/rules/Crypto.list
+++ b/clash/rules/Crypto.list
@@ -222,6 +222,7 @@ DOMAIN-SUFFIX,byffbb.com
 DOMAIN-SUFFIX,bycsi.com
 DOMAIN-SUFFIX,bybitgum.com
 DOMAIN-SUFFIX,content.byabcd.com
+DOMAIN-SUFFIX,appsflyersdk.com
 
 # OKX 补充
 DOMAIN-SUFFIX,contendvc.cnouyi.pizza


### PR DESCRIPTION
This pull request includes a small change to the `clash/rules/Crypto.list` file. The change adds a new domain suffix to the list.

* [`clash/rules/Crypto.list`](diffhunk://#diff-e6fdc21cc7473a888295bb69d4540cc8cd8a52282c5402fd029692505b79673bR225): Added `DOMAIN-SUFFIX,appsflyersdk.com` to the list.