### PR TITLE
update: Add Grok rule provider and corresponding rule set

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -453,6 +453,10 @@ rule-providers:
     <<: *x-rp-text
     url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Anthropic/Anthropic.list
     path: ./providers/rule-provider_Anthropic.list
+  Grok:
+    <<: *x-rp-text
+    url: https://cdn.jsdelivr.net/gh/cc63/Surge@main/Module/Grok.list
+    path: ./providers/rule-provider_Grok.list
   Bing:
     <<: *x-rp-text
     url: https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Bing/Bing.list
@@ -598,6 +602,7 @@ rules:
   - RULE-SET,OpenAI,🇺🇸 美国优选
   - RULE-SET,Anthropic,🇺🇸 美国优选
   - RULE-SET,Gemini,🇺🇸 美国优选
+  - RULE-SET,Grok,🇺🇸 美国优选
   - RULE-SET,Developer,🤖 Developer
   - RULE-SET,GitHub,🤖 Developer
   - RULE-SET,OneDrive,☁️ Onedrive


### PR DESCRIPTION
This pull request updates the Clash configuration file to include a new rule provider for "Grok" and integrates it into the rule set. The changes ensure that traffic matching the "Grok" rules is routed appropriately.

### Additions to rule providers:
* Added a new rule provider for "Grok" with its URL and file path specified in `clash/config/base.yml`.

### Updates to rules:
* Included the "Grok" rule set in the `rules:` section to route traffic through the 🇺🇸 美国优选 group.