### PR TITLE
update: Add OpenRouter rule provider and corresponding rule set

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -457,6 +457,10 @@ rule-providers:
     <<: *x-rp-text
     url: https://fastly.jsdelivr.net/gh/cc63/Surge@main/Module/Grok.list
     path: ./providers/rule-provider_Grok.list
+  OpenRouter:
+    <<: *x-rp-text
+    url: https://fastly.jsdelivr.net/gh/gz4zzxc/rule@main/Clash/rule/OpenRouter.list
+    path: ./providers/rule-provider_OpenRouter.list
   Bing:
     <<: *x-rp-text
     url: https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Bing/Bing.list
@@ -603,6 +607,7 @@ rules:
   - RULE-SET,Anthropic,🇺🇸 美国优选
   - RULE-SET,Gemini,🇺🇸 美国优选
   - RULE-SET,Grok,🇺🇸 美国优选
+  - RULE-SET,OpenRouter,🇺🇸 美国优选
   - RULE-SET,Developer,🤖 Developer
   - RULE-SET,GitHub,🤖 Developer
   - RULE-SET,OneDrive,☁️ Onedrive


### PR DESCRIPTION
This pull request adds a new rule provider and corresponding rule set for `OpenRouter` in the Clash configuration file. These changes expand the configuration's functionality by including a new set of rules for routing traffic.

### Additions to rule providers:

* Added a new rule provider `OpenRouter` with a URL pointing to its rule list and a local path for storage in `clash/config/base.yml`.

### Additions to rules:

* Included a new rule set `OpenRouter` in the `rules` section of `clash/config/base.yml` to route traffic through the corresponding provider.