### PR TITLE
修复：优化新加坡节点匹配规则，避免误匹配新西兰节点

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -473,6 +473,10 @@ rule-providers:
     <<: *x-rp-text
     url: https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GitHub/GitHub.list
     path: ./providers/rule-provider_GitHub.list
+  Cursor:
+    <<: *x-rp-text
+    url: https://fastly.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/cursor.list
+    path: ./providers/rule-provider_Cursor.list
   OneDrive:
     <<: *x-rp-text
     url: https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/OneDrive/OneDrive.list
@@ -610,6 +614,7 @@ rules:
   - RULE-SET,OpenRouter,🇺🇸 美国优选
   - RULE-SET,Developer,🤖 Developer
   - RULE-SET,GitHub,🤖 Developer
+  - RULE-SET,Cursor,🤖 Developer
   - RULE-SET,OneDrive,☁️ Onedrive
   - RULE-SET,YouTube,🎥 Youtube
   - RULE-SET,AppleTV,🎥 Apple TV

--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -319,7 +319,7 @@ proxy-groups:
 
   - name: 🇸🇬 新加坡优选
     <<: *x-pp-region
-    filter: '(?i:🇸🇬|\bSG[P]?\b|Singapore|新加坡|狮城|[^-]新)'
+    filter: '(?i:🇸🇬|\bSG[P]?\b|Singapore|新加坡|狮城)'
 
   - name: 🇰🇷 韩国优选
     <<: *x-pp-region

--- a/clash/rules/cursor.list
+++ b/clash/rules/cursor.list
@@ -1,0 +1,12 @@
+DOMAIN-SUFFIX,cursor.com
+DOMAIN-SUFFIX,cursor.sh
+DOMAIN-SUFFIX,api2.cursor.sh
+DOMAIN-SUFFIX,api3.cursor.sh
+DOMAIN-SUFFIX,api4.cursor.sh
+DOMAIN-SUFFIX,repo42.cursor.sh
+DOMAIN-SUFFIX,us-asia.gcpp.cursor.sh
+DOMAIN-SUFFIX,us-eu.gcpp.cursor.sh
+DOMAIN-SUFFIX,us-only.gcpp.cursor.sh
+DOMAIN-SUFFIX,marketplace.cursorapi.com
+DOMAIN-SUFFIX,cursor-cdn.com
+DOMAIN-SUFFIX,trust.cursor.com

--- a/cursor.list
+++ b/cursor.list
@@ -1,0 +1,12 @@
+DOMAIN-SUFFIX,cursor.com
+DOMAIN-SUFFIX,cursor.sh
+DOMAIN-SUFFIX,api2.cursor.sh
+DOMAIN-SUFFIX,api3.cursor.sh
+DOMAIN-SUFFIX,api4.cursor.sh
+DOMAIN-SUFFIX,repo42.cursor.sh
+DOMAIN-SUFFIX,us-asia.gcpp.cursor.sh
+DOMAIN-SUFFIX,us-eu.gcpp.cursor.sh
+DOMAIN-SUFFIX,us-only.gcpp.cursor.sh
+DOMAIN-SUFFIX,marketplace.cursorapi.com
+DOMAIN-SUFFIX,cursor-cdn.com
+DOMAIN-SUFFIX,trust.cursor.com 


### PR DESCRIPTION
This pull request includes a minor update to the `clash/config/base.yml` file, specifically refining the filter criteria for the "新加坡优选" (Singapore Preferred) proxy group.

### Changes to proxy group filters:
* [`clash/config/base.yml`](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adL322-R322): Removed the `[^-]新` pattern from the filter for the "新加坡优选" proxy group, likely to improve matching accuracy or avoid unintended matches.