### PR TITLE
SG Proxy Group Updates & new rule set for `Cursor` 

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -473,6 +473,10 @@ rule-providers:
     <<: *x-rp-text
     url: https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GitHub/GitHub.list
     path: ./providers/rule-provider_GitHub.list
+  Cursor:
+    <<: *x-rp-text
+    url: https://fastly.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/cursor.list
+    path: ./providers/rule-provider_Cursor.list
   OneDrive:
     <<: *x-rp-text
     url: https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/OneDrive/OneDrive.list
@@ -610,6 +614,7 @@ rules:
   - RULE-SET,OpenRouter,🇺🇸 美国优选
   - RULE-SET,Developer,🤖 Developer
   - RULE-SET,GitHub,🤖 Developer
+  - RULE-SET,Cursor,🤖 Developer
   - RULE-SET,OneDrive,☁️ Onedrive
   - RULE-SET,YouTube,🎥 Youtube
   - RULE-SET,AppleTV,🎥 Apple TV

--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -319,7 +319,7 @@ proxy-groups:
 
   - name: 🇸🇬 新加坡优选
     <<: *x-pp-region
-    filter: '(?i:🇸🇬|\bSG[P]?\b|Singapore|新加坡|狮城|[^-]新)'
+    filter: '(?i:🇸🇬|\bSG[P]?\b|Singapore|新加坡|狮城)'
 
   - name: 🇰🇷 韩国优选
     <<: *x-pp-region

--- a/clash/rules/cursor.list
+++ b/clash/rules/cursor.list
@@ -1,0 +1,12 @@
+DOMAIN-SUFFIX,cursor.com
+DOMAIN-SUFFIX,cursor.sh
+DOMAIN-SUFFIX,api2.cursor.sh
+DOMAIN-SUFFIX,api3.cursor.sh
+DOMAIN-SUFFIX,api4.cursor.sh
+DOMAIN-SUFFIX,repo42.cursor.sh
+DOMAIN-SUFFIX,us-asia.gcpp.cursor.sh
+DOMAIN-SUFFIX,us-eu.gcpp.cursor.sh
+DOMAIN-SUFFIX,us-only.gcpp.cursor.sh
+DOMAIN-SUFFIX,marketplace.cursorapi.com
+DOMAIN-SUFFIX,cursor-cdn.com
+DOMAIN-SUFFIX,trust.cursor.com


### PR DESCRIPTION
This pull request updates the Clash configuration by refining an existing proxy group filter, adding a new rule provider and corresponding rules, and introducing a new domain list for the `Cursor` service. Below are the key changes:

### Proxy Group Updates:
* Refined the filter for the `🇸🇬 新加坡优选` proxy group by removing the `[^-]新` pattern to simplify the matching logic. (`clash/config/base.yml`, [clash/config/base.ymlL322-R322](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adL322-R322))

### Rule Provider Enhancements:
* Added a new rule provider for `Cursor`, including its URL and path configuration. (`clash/config/base.yml`, [clash/config/base.ymlR476-R479](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adR476-R479))

### Rule Updates:
* Introduced a new rule set for `Cursor` under the `rules` section, assigning it to the `🤖 Developer` category. (`clash/config/base.yml`, [clash/config/base.ymlR617](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adR617))

### Domain List Additions:
* Created a new `cursor.list` file containing domain suffixes related to the `Cursor` service. (`cursor.list`, [cursor.listR1-R12](diffhunk://#diff-6541a4c9a3658f4c013092d0b6b3e19a095dfc484ae2640aef4183d11dae0e9fR1-R12))
* Added the same domain suffixes for `Cursor` to the `clash/rules/cursor.list` file for integration with Clash rules. (`clash/rules/cursor.list`, [clash/rules/cursor.listR1-R12](diffhunk://#diff-d9620741eb2a571c07278d2ea3d61be2a16edba1dfd991b6c2cd193b913252d1R1-R12))
This pull request updates the Clash configuration to refine filtering for Singapore servers and add new rule sets for the "Cursor" service. The most significant changes include modifying the Singapore filter, adding a new rule provider for Cursor, and integrating Cursor rules into the configuration.

### Updates to filtering and rule sets:

* **Singapore filter refinement**:
  - Updated the `filter` for the `🇸🇬 新加坡优选` proxy group by removing the `[^-]新` condition to simplify the matching logic. (`clash/config/base.yml`, [clash/config/base.ymlL322-R322](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adL322-R322))

* **Addition of Cursor rule provider**:
  - Added a new rule provider for "Cursor" with its corresponding URL and file path. (`clash/config/base.yml`, [clash/config/base.ymlR476-R479](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adR476-R479))

* **Integration of Cursor rules**:
  - Included "Cursor" in the `rules` section, mapping it to the `🤖 Developer` group. (`clash/config/base.yml`, [clash/config/base.ymlR617](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adR617))

### New Cursor rule definitions:

* **Cursor domain rules**:
  - Added a new file `clash/rules/cursor.list` containing domain suffix rules for various Cursor-related services. (`clash/rules/cursor.list`, [clash/rules/cursor.listR1-R12](diffhunk://#diff-d9620741eb2a571c07278d2ea3d61be2a16edba1dfd991b6c2cd193b913252d1R1-R12))