### PR TITLE
refactor: 优化策略组排序，提升用户体验

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -144,6 +144,16 @@ proxy-groups:
     include-all: true
     exclude-filter: 'ℹ️ .+: \d.+ (?i:KB|MB|GB|TB) \/ \d.+ (?i:KB|MB|GB|TB).*'
 
+  - name: 🎩 私有节点
+    type: select
+    include-all: true
+    filter: "(?i:Private)"
+
+  - name: 🏠 家宽节点
+    type: select
+    include-all: true
+    filter: "(?i:家宽)"
+
   - name: 🍭 谷歌服务
     <<: *x-pp-select-region
 
@@ -282,16 +292,6 @@ proxy-groups:
 
   - name: 🐟 漏网之鱼
     <<: *x-pp-select-region
-
-  - name: 🎩 私有节点
-    type: select
-    include-all: true
-    filter: "(?i:Private)"
-
-  - name: 🏠 家宽节点
-    type: select
-    include-all: true
-    filter: "(?i:家宽)"
 
   - name: 🇭🇰 香港优选
     <<: *x-pp-region


### PR DESCRIPTION
## 修改内容

将 `🎩 私有节点` 和 `🏠 家宽节点` 策略组移动到 `✈️ 手动选择` 后面，优化策略组顺序。

## 修改原因

- 私有节点和家宽节点是用户常用的节点类型
- 将它们放在手动选择后面，便于用户快速访问
- 提升用户使用体验，减少查找时间

## 技术细节

- 在 `clash/config/base.yml` 中重新排列了策略组顺序
- 保持了原有的功能不变，仅调整了位置
- 未影响其他策略组的配置

## 测试

- ✅ 配置文件语法正确
- ✅ 策略组功能正常
- ✅ 不影响现有配置逻辑