### PR TITLE
fix(clash): 修复日本节点正则过滤误匹配尼日利亚的问题

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -303,7 +303,7 @@ proxy-groups:
 
   - name: 🇯🇵 日本优选
     <<: *x-pp-region
-    filter: '(?i:🇯🇵|\bJP[N]?\b|Japan|Tokyo|Osaka|Saitama|日本|东京|大阪|埼玉|日(?!利亚))'
+    filter: '(?i:🇯🇵|\bJP[N]?\b|Japan|Tokyo|Osaka|Saitama|日本|东京|大阪|埼玉|[^-尼]日)'
 
   - name: 🇹🇼 台湾优选
     <<: *x-pp-region

--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -303,7 +303,7 @@ proxy-groups:
 
   - name: 🇯🇵 日本优选
     <<: *x-pp-region
-    filter: '(?i:🇯🇵|\bJP[N]?\b|Japan|Tokyo|Osaka|Saitama|日本|东京|大阪|埼玉|[^-]日)'
+    filter: '(?i:🇯🇵|\bJP[N]?\b|Japan|Tokyo|Osaka|Saitama|日本|东京|大阪|埼玉|日(?!利亚))'
 
   - name: 🇹🇼 台湾优选
     <<: *x-pp-region


### PR DESCRIPTION
## 问题描述
日本节点分组的正则表达式 `[^-]日` 会误匹配到「尼日利亚」节点，导致节点分组不准确。

## 解决方案
- 将 `[^-]日` 改为 `日(?!利亚)` 
- 使用负向前瞻断言排除「尼日利亚」
- 保持对单字「日」的匹配能力
- 提高节点分组的准确性

## 修改内容
- 文件：`clash/config/base.yml`
- 行数：306
- 修改：日本优选分组的过滤正则表达式

## 测试
- ✅ 能正确匹配包含「日」的日本节点
- ✅ 不会误匹配「尼日利亚」节点
- ✅ 其他匹配项（🇯🇵、JP、Japan等）保持不变

## 注意
此PR只包含正则修复的单个commit，不包含其他修改。