### PR TITLE
ci(workflows): replace deprecated ::set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/update-rules.yml
+++ b/.github/workflows/update-rules.yml
@@ -24,7 +24,7 @@ jobs:
         run: python update-Tailscale_OfficialDERP.py
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d %H:%M:%S')"
+        run: echo "date=$(date +'%Y-%m-%d %H:%M:%S')" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
This PR replaces deprecated ::set-output with the recommended GITHUB_OUTPUT in .github/workflows/update-rules.yml.

- Keeps output consumption via ${{ steps.date.outputs.date }} unchanged
- Avoids deprecation warnings and future breakage

Closes #27.