### PR TITLE
refactor(config): update rule providers behavior from classical to do…

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -459,18 +459,16 @@ rule-providers: &base-rule-providers
     behavior: domain
     url: https://fastly.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/MyDirect.list
   MyDirect02:
-    # TODO: switch to domain behavior
     <<: *x-rp-text
-    behavior: classical
+    behavior: domain
     url: https://fastly.jsdelivr.net/gh/gz4zzxc/rule@main/Clash/list/myCN.list
   MyProxy:
     <<: *x-rp-text
     behavior: domain
     url: https://fastly.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/MyProxy.list
   MyProxy02:
-    # TODO: switch to domain behavior
     <<: *x-rp-text
-    behavior: classical
+    behavior: domain
     url: https://fastly.jsdelivr.net/gh/gz4zzxc/rule@main/Clash/list/foreign.list
   # 4. main: p1
   TailscaleDERP_domain:
@@ -617,9 +615,8 @@ rule-providers: &base-rule-providers
     behavior: domain
     url: https://fastly.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/CryptoExtra.list
   HongKongBank:
-    # TODO: switch to domain behavior
     <<: *x-rp-text
-    behavior: classical
+    behavior: domain
     url: https://fastly.jsdelivr.net/gh/gz4zzxc/rule@main/Clash/rule/HongKongBank.list
   # 7. main: p4
   MicrosoftDirect:


### PR DESCRIPTION
This pull request updates the rule provider configurations in `clash/config/base.yml` to ensure consistent behavior settings. Specifically, several rule providers previously set to `classical` behavior have been switched to `domain` behavior, aligning them with the rest of the configuration and removing outdated TODO comments.

Rule provider behavior updates:

* Changed `MyDirect02` rule provider from `classical` to `domain` behavior for consistency.
* Changed `MyProxy02` rule provider from `classical` to `domain` behavior for consistency.
* Changed `HongKongBank` rule provider from `classical` to `domain` behavior for consistency.

Cleanup:

* Removed obsolete TODO comments related to switching behaviors in the affected rule providers. [[1]](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adL462-R471) [[2]](diffhunk://#diff-9a41efd472eecc88a87d547f359afd470daa1afd5f851f131e7145ba46f648adL620-R619)…main