### PR TITLE
fix: remove deprecated global-client-fingerprint

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -185,7 +185,6 @@ profile:
 external-controller: 127.0.0.1:9090
 unified-delay: true
 tcp-concurrent: true
-global-client-fingerprint: chrome
 geo-auto-update: true
 geo-update-interval: 24
 geox-url:


### PR DESCRIPTION
## Summary
- remove deprecated `global-client-fingerprint` from `clash/config/base.yml`
- align config with mihomo guidance to set `client-fingerprint` per proxy/provider override instead of globally
- keep behavior minimal by only deleting the deprecated global key

## Related
Closes #32