### PR TITLE
feat: separate Polymarket routing

### DIFF
--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -387,8 +387,8 @@ proxy-groups:
 
   - name: 🔮 Polymarket
     <<: *x-pg-control-select-proxy
-    # Keep Polymarket independent from Crypto; Hong Kong is the default
-    # non-Korea route, while the remaining choices stay manually selectable.
+    # View-only routing: keep close-only regions available for reading markets.
+    # Korea is excluded because it is unreachable in the current environment.
     proxies:
       - 🇭🇰 香港优选
       - 🔰 节点选择
@@ -400,7 +400,6 @@ proxy-groups:
       - 🇯🇵 日本优选
       - 🇹🇼 台湾优选
       - 🇸🇬 新加坡优选
-      - 🇰🇷 韩国优选
       - 🎯 全部直连
 
   - name: 💬 Telegram

--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -387,20 +387,6 @@ proxy-groups:
 
   - name: 🔮 Polymarket
     <<: *x-pg-control-select-proxy
-    # View-only routing: keep close-only regions available for reading markets.
-    # Korea is excluded because it is unreachable in the current environment.
-    proxies:
-      - 🇭🇰 香港优选
-      - 🔰 节点选择
-      - ✈️ 手动选择
-      - 🎩 私有节点
-      - 🏠 家宽节点
-      - 📥 高耗流量
-      - 🇺🇸 美国优选
-      - 🇯🇵 日本优选
-      - 🇹🇼 台湾优选
-      - 🇸🇬 新加坡优选
-      - 🎯 全部直连
 
   - name: 💬 Telegram
     <<: *x-pg-control-select-proxy
@@ -592,13 +578,13 @@ sub-rules:
     - GEOSITE,category-emby,🎥 Emby Providers
     - GEOSITE,spotify,🎵 Spotify
     - RULE-SET,Qobuz,🎵 Qobuz
+    - RULE-SET,PolymarketExtra,🔮 Polymarket
     # domain: category
     - RULE-SET,RestrictedZones,🈲 Restricted
     - GEOSITE,category-games-!cn,🎮 Games
     - GEOSITE,category-ai-!cn,✨ GenAI
     - RULE-SET,GenAiExtra,✨ GenAI
     - GEOSITE,category-dev,💻 Developer
-    - RULE-SET,PolymarketExtra,🔮 Polymarket
     - GEOSITE,category-cryptocurrency,💰 Crypto
     - RULE-SET,CryptoExtra,💰 Crypto
     - GEOSITE,category-finance,💰 Finance

--- a/clash/config/base.yml
+++ b/clash/config/base.yml
@@ -385,6 +385,24 @@ proxy-groups:
   - name: 💰 Crypto
     <<: *x-pg-control-select-proxy
 
+  - name: 🔮 Polymarket
+    <<: *x-pg-control-select-proxy
+    # Keep Polymarket independent from Crypto; Hong Kong is the default
+    # non-Korea route, while the remaining choices stay manually selectable.
+    proxies:
+      - 🇭🇰 香港优选
+      - 🔰 节点选择
+      - ✈️ 手动选择
+      - 🎩 私有节点
+      - 🏠 家宽节点
+      - 📥 高耗流量
+      - 🇺🇸 美国优选
+      - 🇯🇵 日本优选
+      - 🇹🇼 台湾优选
+      - 🇸🇬 新加坡优选
+      - 🇰🇷 韩国优选
+      - 🎯 全部直连
+
   - name: 💬 Telegram
     <<: *x-pg-control-select-proxy
 
@@ -508,6 +526,10 @@ rule-providers:
     <<: *x-rp-text
     behavior: domain
     url: https://testingcf.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/CryptoExtra.list
+  PolymarketExtra:
+    <<: *x-rp-text
+    behavior: domain
+    url: https://testingcf.jsdelivr.net/gh/jimlee2048/atc-config@main/clash/rules/PolymarketExtra.list
   FinanceExtra:
     <<: *x-rp-text
     behavior: domain
@@ -577,6 +599,7 @@ sub-rules:
     - GEOSITE,category-ai-!cn,✨ GenAI
     - RULE-SET,GenAiExtra,✨ GenAI
     - GEOSITE,category-dev,💻 Developer
+    - RULE-SET,PolymarketExtra,🔮 Polymarket
     - GEOSITE,category-cryptocurrency,💰 Crypto
     - RULE-SET,CryptoExtra,💰 Crypto
     - GEOSITE,category-finance,💰 Finance

--- a/clash/rules/PolymarketExtra.list
+++ b/clash/rules/PolymarketExtra.list
@@ -1,0 +1,2 @@
+# polymarket
++.polymarket.com


### PR DESCRIPTION
## Summary
- add a dedicated `🔮 Polymarket` proxy group with Hong Kong as the default route
- add `PolymarketExtra` for `+.polymarket.com`
- place the dedicated rule before `GEOSITE,category-cryptocurrency` so Crypto selection does not affect Polymarket

## View-only routing
- this setup is for viewing markets, not opening positions
- keep Hong Kong, US, Japan, Singapore, and Taiwan choices available for viewing/market data
- exclude Korea because it is completely unreachable in the current environment
- keep the manual and other existing control choices available for user-selected exits

References: https://docs.polymarket.com/api-reference/geoblock and https://help.polymarket.com/en/articles/13364163-geographic-restrictions

## Validation
- YAML parsing passed
- view-only Polymarket route and rule order checks passed
- `git diff --check` passed